### PR TITLE
fix: prevent shallow merging of nested fields (#7)

### DIFF
--- a/src/topics/hooks/useReducer/04.RegistrationFromManage.jsx
+++ b/src/topics/hooks/useReducer/04.RegistrationFromManage.jsx
@@ -26,6 +26,7 @@ const initialState = {
 
 const ACTIONS = {
   UPDATE_FIELD: "update-field",
+  UPDATE_NESTED_FIELD: "update-nested-field",
   TOGGLE_CHECKBOX: "toggle-checkbox",
   SUBMIT_FORM: "submit-form",
   SET_ERROR: "set-error",
@@ -37,6 +38,7 @@ const ACTIONS = {
 };
 
 const formReducer = (state, action) => {
+  console.log("Action dispatched:", action);
   switch (action.type) {
     case ACTIONS.UPDATE_FIELD:
       return {
@@ -46,6 +48,19 @@ const formReducer = (state, action) => {
           ...action.payload,
         },
       };
+
+    case ACTIONS.UPDATE_NESTED_FIELD:
+      return {
+        ...state,
+        formData:{
+          ...state.formData,
+          [action.payload.section]:{
+            ...state.formData[action.payload.section],
+            ...action.payload.data,
+          }
+        }
+      };
+
     case ACTIONS.TOGGLE_CHECKBOX:
       return {
         ...state,
@@ -104,24 +119,29 @@ const validateForm = (formData) => {
 
 const RegistrationFormManage = () => {
   const [state, dispatch] = useReducer(formReducer, initialState);
-
+  console.log("Current state:", state);
   const handleInputChange = (event) => {
     const { name, value } = event.target;
 
-    if (name === "country" || name === "city" || name === "zipCode") {
+    if (["country", "city", "zipCode"].includes(name)) {
       dispatch({
-        type: ACTIONS.UPDATE_FIELD,
+        type: ACTIONS.UPDATE_NESTED_FIELD,
         payload: {
-          address: {
-            ...state.formData.address,
-            [name]: value,
-          },
+          section: "address",
+          data: { [name]: value },
         },
       });
+    } else if (name === "contactMethod") {
+      dispatch({
+        type: ACTIONS.UPDATE_NESTED_FIELD,
+        payload: {
+          section: "preference",
+          data: { [name]: value },
+        },
+      })
     } else if (
       name === "skills" ||
-      name === "newsletter" ||
-      name === "contactMethod"
+      name === "newsletter"
     ) {
       const skills = state.formData.preference.skills.includes(value)
         ? state.formData.preference.skills.filter((skill) => skill !== value)
@@ -132,11 +152,6 @@ const RegistrationFormManage = () => {
           ? !state.formData.preference.newsletter
           : state.formData.preference.newsletter;
 
-      const contactMethod =
-        name === "contactMethod"
-          ? value
-          : state.formData.preference.contactMethod;
-
       dispatch({
         type: ACTIONS.UPDATE_FIELD,
         payload: {
@@ -144,7 +159,6 @@ const RegistrationFormManage = () => {
             ...state.formData.preference,
             skills,
             newsletter,
-            contactMethod,
           },
         },
       });


### PR DESCRIPTION
This pull request addresses a bug where updating a nested field in the form state (e.g., `address.country`) unintentionally overwrites other fields in that nested object (e.g., `address.city`, `address.zipCode`).

Previously, the reducer performed a shallow merge of the formData object:
```
formData: {
  ...state.formData,
  ...action.payload,
}
```

### 🧨 Example of the Bug (Before)
```
// Initial state
formData: {
  address: {
    country: "Bangladesh",
    city: "Dhaka",
    zipCode: "1205"
  }
}

// Update payload
payload: {
  address: {
    country: "India"
  }
}

// Result after reducer
formData: {
  address: {
    country: "India" // city and zipCode are now missing
  }
}
```

### ✅ What’s Fixed

We now perform a **manual deep merge** of nested objects like `address` and `preference`, ensuring only the specific fields are updated, and the rest are preserved.
```
 case ACTIONS.UPDATE_NESTED_FIELD:
      return {
        ...state,
        formData:{
          ...state.formData,
          [action.payload.section]:{
            ...state.formData[action.payload.section],
            ...action.payload.data,
          }
        }
      };
```

### 🔍 Why It Matters

- Prevents accidental data loss in form state.
- Ensures correct behavior when handling dynamic form inputs.


### 📌 Related Issue

Closes #7